### PR TITLE
get_events now cancels cleanly (fixes #278), fixed output log formatting, etc cleanup

### DIFF
--- a/seed_vault/service/config.cfg
+++ b/seed_vault/service/config.cfg
@@ -72,6 +72,8 @@ maxsearchradius = 25.31972581344694
 # don't change. if you are searching a network in [AUTH] it will change this flag
 includerestricted = False
 level = channel
+
+
 [EVENT]
 # see: https://www.auspass.edu.au/fdsnws/event/1/builder
 
@@ -89,8 +91,8 @@ minmagnitude = 5.2
 maxmagnitude = 7.1
 
 # These are relative to the individual stations
-minradius = 0.0
-maxradius = 30.0
+minradius = 30.0
+maxradius = 90.0
 
 # if set, load events from a local QuakeML file
 local_catalog = 

--- a/seed_vault/service/waveform.py
+++ b/seed_vault/service/waveform.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import os
+from typing import Tuple
 import obspy
 from obspy import UTCDateTime
 from obspy.clients.filesystem.sds import Client as LocalClient
@@ -35,7 +36,23 @@ def check_is_archived(cursor, req: SeismoQuery):
         return False
     return True
 
+def get_local_waveform(request: Tuple[str, str, str, str, str, str], settings: SeismoLoaderSettings):
+    client = LocalClient(settings.sds_path)
+    kwargs = {
+        'network': request[0].upper(),
+        'station': request[1].upper(),
+        'location': request[2].upper(),
+        'channel': request[3].upper(),
+        'starttime': UTCDateTime(request[4]),
+        'endtime': UTCDateTime(request[5])
+        }
+    try:
+        return client.get_waveforms(**kwargs)
+    except:
+        return None
+
 #this is a simpler version.. if the data doesn't exist it just returns an empty stream
+"""
 def get_local_waveform(req: SeismoQuery, settings: SeismoLoaderSettings):
     client = LocalClient(settings.sds_path)
     st = client.get_waveforms(network=req.network,station=req.station,
@@ -46,3 +63,4 @@ def get_local_waveform(req: SeismoQuery, settings: SeismoLoaderSettings):
     #if not st:
     #    raise NotFoundError("Not Found: the requested data was not found in local archived database.")
     return st
+"""


### PR DESCRIPTION
1) when cancel is activated in run_event, code now finishes the last request and moves onto plotting (if any waveforms were retrieved)

2) the UI log output now respects newlines from seismoloader, more of a literal translation. there is still a weird bug if a print line is empty or just `\n` or even starts with `\n` but a workaround is `print(' ')` with a space. last I checked run_continuous didn't have this problem. 

3) change default search radius to 30-90, change the increment in the UI from .01 to 0.5

4) remove some excessive cancel catches in run_event and run_continuous

5) rewrite get_local_waveform in service/waveform.py